### PR TITLE
add: date range filter for spec rankings

### DIFF
--- a/src/components/SettingsBar/FilterSettings/FilterDateRange.module.scss
+++ b/src/components/SettingsBar/FilterSettings/FilterDateRange.module.scss
@@ -1,0 +1,19 @@
+.date_range_group {
+    max-height: 1.5rem;
+}
+
+.date_input {
+    height: initial;
+    padding: 12px 4px;
+    border-radius: 0.25rem;
+    line-height: initial;
+}
+
+.is_empty:not(:focus) {
+    color: #6c757d;
+}
+
+.is_filled:not(:focus) {
+    font-weight: bold;
+    border: var(--success) solid 2px;
+}

--- a/src/components/SettingsBar/FilterSettings/FilterDateRange.tsx
+++ b/src/components/SettingsBar/FilterSettings/FilterDateRange.tsx
@@ -3,6 +3,7 @@ import { useDispatch } from 'react-redux'
 
 import { set_filters } from '../../../store/ui'
 import ButtonGroup from '../shared/ButtonGroup'
+import styles from './FilterDateRange.module.scss'
 
 
 export default function FilterDateRangeGroup() {
@@ -30,19 +31,21 @@ export default function FilterDateRangeGroup() {
     }
 
     return (
-        <ButtonGroup name="Date">
-            <div className="d-flex gap-1">
+        <ButtonGroup name="Date Range">
+            <div className={`d-flex gap-1 ${styles.date_range_group}`}>
                 <input
                     type="date"
                     value={from}
                     onChange={e => on_change_from(e.target.value)}
                     aria-label="From date"
+                    className={`form-control ${styles.date_input} ${from ? styles.is_filled : styles.is_empty}`}
                 />
                 <input
                     type="date"
                     value={to}
                     onChange={e => on_change_to(e.target.value)}
                     aria-label="To date"
+                    className={`form-control ${styles.date_input} ${to ? styles.is_filled : styles.is_empty}`}
                 />
             </div>
         </ButtonGroup>

--- a/src/components/SettingsBar/FilterSettings/FilterDateRange.tsx
+++ b/src/components/SettingsBar/FilterSettings/FilterDateRange.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react'
+import { useDispatch } from 'react-redux'
+
+import { set_filters } from '../../../store/ui'
+import ButtonGroup from '../shared/ButtonGroup'
+
+
+export default function FilterDateRangeGroup() {
+    const dispatch = useDispatch()
+    const [from, setFrom] = useState<string>("")
+    const [to, setTo] = useState<string>("")
+
+    function update_filter(next_from: string, next_to: string) {
+        dispatch(set_filters({
+            log_date: {
+                from: next_from || null,
+                to: next_to || null,
+            }
+        }))
+    }
+
+    function on_change_from(value: string) {
+        setFrom(value)
+        update_filter(value, to)
+    }
+
+    function on_change_to(value: string) {
+        setTo(value)
+        update_filter(from, value)
+    }
+
+    return (
+        <ButtonGroup name="Date">
+            <div className="d-flex gap-1">
+                <input
+                    type="date"
+                    value={from}
+                    onChange={e => on_change_from(e.target.value)}
+                    aria-label="From date"
+                />
+                <input
+                    type="date"
+                    value={to}
+                    onChange={e => on_change_to(e.target.value)}
+                    aria-label="To date"
+                />
+            </div>
+        </ButtonGroup>
+    )
+}

--- a/src/components/SettingsBar/FilterSettings/FilterSettings.tsx
+++ b/src/components/SettingsBar/FilterSettings/FilterSettings.tsx
@@ -1,3 +1,4 @@
+import FilterDateRangeGroup from './FilterDateRange'
 import FilterKilltimeGroup from './FilterKilltime'
 import RegionFilterGroup from './RegionFilter'
 
@@ -7,6 +8,7 @@ export default function FilterSettings() {
         <>
             <RegionFilterGroup />
             <FilterKilltimeGroup />
+            <FilterDateRangeGroup />
         </>
     )
 }

--- a/src/filter_logic.ts
+++ b/src/filter_logic.ts
@@ -5,6 +5,16 @@ import type Actor from "./types/actor"
 import type Fight from "./types/fight"
 
 
+function get_date_floor_ms(date_str: string): number {
+    return Date.parse(`${date_str}T00:00:00.000Z`)
+}
+
+
+function get_date_ceil_ms(date_str: string): number {
+    return Date.parse(`${date_str}T23:59:59.999Z`)
+}
+
+
 function is_fight_visible(fight: Fight, filters: FilterValues) {
 
     if (fight.pinned) { return true }
@@ -15,6 +25,18 @@ function is_fight_visible(fight: Fight, filters: FilterValues) {
 
     if (fight.region && filters.region && filters.region[fight.region] === false) {
         return false
+    }
+
+    const from = filters.log_date?.from
+    const to = filters.log_date?.to
+    if (from || to) {
+        if (!fight.start_time) { return false }
+
+        const fight_ms = Date.parse(fight.start_time)
+        if (Number.isNaN(fight_ms)) { return false }
+
+        if (from && fight_ms < get_date_floor_ms(from)) { return false }
+        if (to && fight_ms > get_date_ceil_ms(to)) { return false }
     }
 
     const has_boss = fight.boss && is_player_visible(fight.boss, filters)

--- a/src/store/fights.ts
+++ b/src/store/fights.ts
@@ -224,6 +224,7 @@ async function _load_spec_rankings(
     spec_ranking.reports?.forEach((report, i) => {
         report.fights?.forEach(fight => {
             fight.report_id = report.report_id
+            fight.start_time = fight.start_time ?? report.start_time
             fight.difficulty = fight.difficulty ?? get_difficulty_id(difficulty);
             fight.region = report.region
             fights.push(fight)

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -76,6 +76,7 @@ type FilterGroup =
 export interface FilterValues {
 
     killtime: { min: number | null, max: number | null }
+    log_date: { from: string | null, to: string | null }
 
     /** Filter Groups like:
      * role: { tank: false, heal: true}
@@ -165,6 +166,7 @@ const INITIAL_STATE: UiSliceState = {
 
         // fight filters
         killtime: { min: null, max: null },
+        log_date: { from: null, to: null },
 
         hide_empty_rows: false,
         spells: {},


### PR DESCRIPTION
adding a date range filter so that users can review rotations/logs filtered based on date of patch drops. 

ex: UH dk rotation changed as of 12.0.5, and reviewing top logs may be misleading if you don't focus on 12.0.5 and beyond. doing so currently requires you to click into each individual log and check date on WCL.